### PR TITLE
Using $.children instead of $.find to avoid problems with nested <ul>.

### DIFF
--- a/js/foundation/foundation.balancer.js
+++ b/js/foundation/foundation.balancer.js
@@ -72,17 +72,17 @@
 				}
 				
 				//balance the blocks
-				$(this).find('li').css("width", (100 / grid)+"%");
-				$(this).find('li').css(rtl,0);
+				$(this).children('li').css("width", (100 / grid)+"%");
+				$(this).children('li').css(rtl,0);
 				 
 				 var offset = blocks % grid;
 				 
 				 for (var b = 0; b <= blocks % grid; b++) {
 					if (Foundation.libs.balancer.settings.respectSiblingWidth == false) {
-						$(this).find('li').eq(blocks-b).css("width",(100 / offset)+"%");
+						$(this).children('li').eq(blocks-b).css("width",(100 / offset)+"%");
 					} else {
 						if (b == offset) {
-							$(this).find('li').eq(blocks-b).css(rtl, (((grid - offset) * .5) * (100 / grid))+"%");	
+							$(this).children('li').eq(blocks-b).css(rtl, (((grid - offset) * .5) * (100 / grid))+"%");	
 						}
 					}
 				 }


### PR DESCRIPTION
Without this change the plugin will change the width of nested lists. In the code below, all elements with class="element" will also have their width changed, instead of just the parent `<li>`.

``` html
<ul class="small-block-grid-2" data-balancer>
  <li>
    <ul><li class="element">element1</li><li class="element">element2</li></ul>
  </li>
  <li>
    <ul><li class="element">element1</li><li class="element">element2</li></ul>
  </li>
</ul>
```

Thank you for this plugin.
